### PR TITLE
Add debug logging for demo plugins

### DIFF
--- a/src/PVE/BackupProvider/Plugin/Demo.pm
+++ b/src/PVE/BackupProvider/Plugin/Demo.pm
@@ -1,0 +1,304 @@
+package PVE::BackupProvider::Plugin::Demo;
+
+use strict;
+use warnings;
+
+use File::Path qw(make_path);
+use File::Copy;
+use POSIX qw(strftime);
+
+use base qw(PVE::BackupProvider::Plugin::Base);
+
+sub new {
+    my ($class, $storage_plugin, $scfg, $storeid, $log_function) = @_;
+
+    my $self = bless {
+        storage_plugin => $storage_plugin,
+        scfg => $scfg,
+        storeid => $storeid,
+        log_function => $log_function,
+    }, $class;
+
+    $self->{scfg}->{path} //= '/tmp/demo';
+
+    # store archives inside the storage's backup directory so that the
+    # associated storage plugin can list them correctly
+    $self->{backup_path} = $storage_plugin->get_subdir($self->{scfg}, 'backup');
+    make_path($self->{backup_path});
+
+    return $self;
+}
+
+sub _log {
+    my ($self, $msg) = @_;
+    my $ts = strftime('%Y-%m-%d %H:%M:%S', localtime());
+    if (open(my $fh, '>>', '/tmp/demo.log')) {
+        print $fh "[$ts] $msg\n";
+        close($fh);
+    }
+    if (my $log = $self->{log_function}) {
+        eval { $log->('info', $msg); };
+    }
+}
+
+sub provider_name {
+    return 'DemoProvider';
+}
+
+sub job_init {
+    my ($self, $start_time) = @_;
+    $self->_log("job_init at $start_time");
+    return {};
+}
+
+sub job_cleanup {
+    my ($self) = @_;
+    $self->_log('job_cleanup');
+    return {};
+}
+
+sub backup_init {
+    my ($self, $vmid, $vmtype, $start_time) = @_;
+    my $suffix = $vmtype eq 'lxc' ? '.tar' : '';
+    my $name = "demo-$vmtype-$vmid-$start_time$suffix";
+    $self->{current_archive} = $name;
+    $self->{vmtype} = $vmtype;
+    $self->{start_time} = $start_time;
+    $self->_log("backup_init $name for VMID $vmid type $vmtype");
+    return { 'archive-name' => $name };
+}
+
+sub _vm_archive_files {
+    my ($self) = @_;
+    my $base = "$self->{backup_path}/$self->{current_archive}";
+    my @files;
+    if ($self->{vmtype} eq 'lxc') {
+        push @files, "$base";
+    } else {
+        push @files, glob("$base-*.raw"), "$base.conf";
+    }
+    return @files;
+}
+
+sub backup_cleanup {
+    my ($self, $vmid, $vmtype, $success, $info) = @_;
+    my $size = 0;
+    $size += (stat($_))[7] // 0 for $self->_vm_archive_files();
+    $self->_log("backup_cleanup size=$size success=$success");
+    return { stats => { 'archive-size' => $size } };
+}
+
+sub backup_get_mechanism {
+    my ($self, $vmid, $vmtype) = @_;
+    return $vmtype eq 'lxc' ? 'directory' : 'file-handle';
+}
+
+sub backup_handle_log_file {
+    my ($self, $vmid, $filename) = @_;
+    my $dest = "$self->{backup_path}/$self->{current_archive}.log";
+    File::Copy::copy($filename, $dest);
+    $self->_log("stored log $dest");
+    return {};
+}
+
+sub backup_vm_query_incremental {
+    return;
+}
+
+sub backup_vm {
+    my ($self, $vmid, $guest_config, $volumes, $info) = @_;
+
+    my $base = "$self->{backup_path}/$self->{current_archive}";
+    if (defined $guest_config) {
+        my $cfgpath = "$base.conf";
+        open(my $fh, '>', $cfgpath) or die "unable to write $cfgpath: $!";
+        print $fh $guest_config;
+        close($fh);
+    }
+
+    foreach my $dev (sort keys %$volumes) {
+        my $fh = $volumes->{$dev}->{'file-handle'}
+            or die "missing file handle for $dev";
+
+        my $name = $dev;
+        $name =~ s/^drive-//;
+
+        my $dest = "$base-$name.raw";
+        $self->_log("start copying VM disk $dev to $dest");
+        open(my $out, '>', $dest) or die "unable to create $dest: $!";
+        my $buf;
+        while (my $count = sysread($fh, $buf, 8192)) {
+            die "read failed: $!" if !defined $count;
+            last if $count == 0;
+            my $written = syswrite($out, $buf, $count);
+            die "write failed: $!" if !defined $written || $written != $count;
+        }
+        close($out);
+        $self->_log("written VM disk $dev to $dest");
+    }
+
+    return {};
+}
+
+sub backup_container_prepare {
+    my ($self, $vmid, $guest_config, $exclude, $info) = @_;
+    $self->_log("backup_container_prepare for $vmid");
+    return {};
+}
+
+sub backup_container {
+    my ($self, $vmid, $guest_config, $exclude, $info) = @_;
+
+    my $src = $info->{directory} or die "missing directory path";
+    my $archive = "$self->{backup_path}/$self->{current_archive}";
+
+    my $tmpconf = "$self->{backup_path}/config.$$";
+    if (defined $guest_config) {
+        open(my $fh, '>', $tmpconf) or die "unable to write temp config $tmpconf: $!";
+        print $fh $guest_config;
+        close($fh);
+    }
+
+    $self->_log("creating container tar archive $archive from $src");
+
+    system('tar', 'cf', $archive, '-C', $src, '.') == 0 or die "tar failed";
+
+    if (-f $tmpconf) {
+        $self->_log("adding container config to $archive");
+        system('tar', 'rf', $archive, '-C', $self->{backup_path}, 'config.$$') == 0 or die "tar add failed";
+        unlink $tmpconf;
+    }
+
+    $self->_log("container data archived at $archive");
+    return {};
+}
+
+sub _setup_restore {
+    my ($self, $volname) = @_;
+
+    return if defined($self->{restore_vmtype});
+
+    my $path = $self->{storage_plugin}->filesystem_path($self->{scfg}, $volname);
+    if ($volname =~ /\.tar$/) {
+        $self->{restore_archive} = $path;
+        $self->{restore_vmtype} = 'lxc';
+    } else {
+        $self->{restore_base} = $path;
+        $self->{restore_vmtype} = 'qemu';
+    }
+    my $exists = -e $path ? 'exists' : 'missing';
+    $self->_log("_setup_restore for $volname -> $path ($exists) type $self->{restore_vmtype}");
+}
+
+sub restore_get_mechanism {
+    my ($self, $volname) = @_;
+
+    $self->_setup_restore($volname);
+    my ($mech, $type);
+    if ($self->{restore_vmtype} eq 'lxc') {
+        ($mech, $type) = ('tar', 'lxc');
+    } else {
+        ($mech, $type) = ('qemu-img', 'qemu');
+    }
+    $self->_log("restore_get_mechanism $volname -> $mech type $type");
+    return ($mech, $type);
+}
+
+sub archive_get_guest_config {
+    my ($self, $volname, $storeid) = @_;
+
+    $self->_setup_restore($volname);
+
+    my $cfg = '';
+    if ($self->{restore_vmtype} eq 'lxc') {
+        my $path = $self->{restore_archive};
+        if (-f $path) {
+            open(my $fh, '-|', 'tar', '-O', '-xf', $path, 'config');
+            local $/; $cfg = <$fh>; close($fh);
+        }
+    } else {
+        my $cfgpath = "$self->{restore_base}.conf";
+        if (-f $cfgpath) {
+            open(my $fh, '<', $cfgpath) or die "unable to read $cfgpath: $!";
+            local $/; $cfg = <$fh>; close($fh);
+        }
+    }
+
+    $self->_log("archive_get_guest_config read length=" . length($cfg));
+    return $cfg;
+}
+
+sub archive_get_firewall_config { return undef; }
+
+sub restore_vm_init {
+    my ($self, $volname) = @_;
+
+    $self->_setup_restore($volname);
+    $self->_log("restore_vm_init $volname");
+
+    my %vols;
+    for my $file (glob("$self->{restore_base}-*.raw")) {
+        my $dev = $file;
+        $dev =~ s/^\Q$self->{restore_base}\E-//;
+        next if $dev eq $file; # safety
+        $dev =~ s/\.raw$//;
+        my $size = -s $file;
+        $self->_log("found volume file $file dev=$dev size=" . (defined $size ? $size : 'undef'));
+        next if !defined $size;
+        $vols{$dev} = { size => $size };
+        $vols{"drive-$dev"} //= { size => $size };
+    }
+
+    $self->_log('no volume files found') if !%vols;
+
+    return \%vols;
+}
+
+sub restore_vm_cleanup {
+    my ($self, $volname) = @_;
+
+    $self->_setup_restore($volname);
+    $self->_log("restore_vm_cleanup $volname");
+    return {};
+}
+
+sub restore_vm_volume_init {
+    my ($self, $volname, $device_name, $info) = @_;
+
+    $self->_setup_restore($volname);
+    my $name = $device_name;
+    $name =~ s/^drive-//;
+    my $path = "$self->{restore_base}-$name.raw";
+    if (-f $path) {
+        $self->_log("restore_vm_volume_init $device_name -> $path size=" . (-s $path));
+    } else {
+        $self->_log("restore_vm_volume_init $device_name -> $path NOT FOUND");
+    }
+    return { 'qemu-img-path' => $path };
+}
+
+sub restore_vm_volume_cleanup {
+    my ($self, $volname, $device_name, $info) = @_;
+
+    $self->_setup_restore($volname);
+    $self->_log("restore_vm_volume_cleanup $device_name");
+    return {};
+}
+
+sub restore_container_init {
+    my ($self, $volname, $info) = @_;
+
+    $self->_setup_restore($volname);
+    $self->_log("restore_container_init $volname -> $self->{restore_archive}");
+    return { 'tar-path' => $self->{restore_archive} };
+}
+
+sub restore_container_cleanup {
+    my ($self, $volname, $info) = @_;
+
+    $self->_setup_restore($volname);
+    $self->_log("restore_container_cleanup $volname");
+    return {};
+}
+
+1;

--- a/src/PVE/BackupProvider/Plugin/Makefile
+++ b/src/PVE/BackupProvider/Plugin/Makefile
@@ -1,4 +1,4 @@
-SOURCES = Base.pm
+SOURCES = Base.pm Demo.pm
 
 .PHONY: install
 install:

--- a/src/PVE/Storage/Custom/DemoPlugin.pm
+++ b/src/PVE/Storage/Custom/DemoPlugin.pm
@@ -1,0 +1,177 @@
+package PVE::Storage::Custom::DemoPlugin;
+
+use strict;
+use warnings;
+
+use File::Basename qw(basename);
+use File::stat;
+use POSIX qw(strftime);
+
+use PVE::Storage; # for APIVER constant
+
+use base qw(PVE::Storage::DirPlugin);
+
+sub _log {
+    my ($msg) = @_;
+    my $ts = strftime('%Y-%m-%d %H:%M:%S', localtime());
+    if (open(my $fh, '>>', '/tmp/demo.log')) {
+        print $fh "[$ts] [Storage] $msg\n";
+        close($fh);
+    }
+}
+
+sub type {
+    return 'demo';
+}
+
+sub plugindata {
+    return {
+        content => [ { backup => 1 }, { backup => 1 } ],
+        features => { 'backup-provider' => 1 },
+        'sensitive-properties' => {},
+    };
+}
+
+# no additional properties over DirPlugin
+sub properties {
+    return {};
+}
+
+
+# path defaults to /tmp/demo via check_config
+
+
+sub options {
+    return {
+        path => { optional => 1 },
+        'content-dirs' => { optional => 1 },
+        nodes => { optional => 1 },
+        shared => { optional => 1 },
+        disable => { optional => 1 },
+        maxfiles => { optional => 1 },
+        'prune-backups' => { optional => 1 },
+        'max-protected-backups' => { optional => 1 },
+        content => { optional => 1 },
+        format => { optional => 1 },
+        mkdir => { optional => 1 },
+        'create-base-path' => { optional => 1 },
+        'create-subdirs' => { optional => 1 },
+        is_mountpoint => { optional => 1 },
+        bwlimit => { optional => 1 },
+        preallocation => { optional => 1 },
+    };
+}
+
+sub parse_volname {
+    my ($class, $volname) = @_;
+
+    _log("parse_volname $volname");
+
+    if ($volname =~ m!^backup/(demo-(lxc|qemu)-(\d+)-(\d+))(\.tar)?$!) {
+        my $name = $1 . ($5 // '');
+        my $vmid = $3;
+        my $fmt  = defined($5) ? 'tar' : 'raw';
+        _log("parsed demo backup $volname -> $name vmid=$vmid format=$fmt");
+        return ('backup', $name, $vmid, undef, undef, undef, $fmt);
+    }
+
+    my @res = $class->SUPER::parse_volname($volname);
+    _log("parse_volname fallback -> " . join(' ', @res));
+    return @res;
+}
+
+sub _list_demo_backups {
+    my ($class, $storeid, $path, $vmid) = @_;
+
+    _log("_list_demo_backups path=$path vmid=" . (defined $vmid ? $vmid : 'all'));
+
+    my $res = [];
+
+        foreach my $file (glob("$path/demo-lxc-*-*.tar")) {
+            next if $vmid && $file !~ /demo-lxc-$vmid-/;
+            my $st = File::stat::stat($file) or next;
+            my $name = basename($file);
+            _log("found lxc backup $name size=" . $st->size);
+            push @$res, {
+                volid   => "$storeid:backup/$name",
+                format  => 'tar',
+                size    => $st->size,
+                ctime   => $st->ctime,
+                content => 'backup',
+                vmid    => ($name =~ /^demo-lxc-(\d+)-/ ? $1 : undef),
+                subtype => 'lxc',
+            };
+        }
+
+    foreach my $conf (glob("$path/demo-qemu-*-*.conf")) {
+        next if $vmid && $conf !~ /demo-qemu-$vmid-/;
+        my $prefix = $conf;
+        $prefix =~ s/\.conf$//;
+        my $name = basename($prefix);
+        my $size = 0;
+        my $ctime = 0;
+        for my $f (glob("$prefix-*.raw"), $conf) {
+            my $st = File::stat::stat($f) or next;
+            $size += $st->size;
+            $ctime = $st->ctime if $st->ctime > $ctime;
+        }
+        _log("found qemu backup $name size=$size");
+        push @$res, {
+            volid   => "$storeid:backup/$name",
+            format  => 'raw',
+            size    => $size,
+            ctime   => $ctime,
+            content => 'backup',
+            vmid    => ($name =~ /^demo-qemu-(\d+)-/ ? $1 : undef),
+            subtype => 'qemu',
+        };
+    }
+
+    return $res;
+}
+
+sub list_volumes {
+    my ($class, $storeid, $scfg, $vmid, $content_types) = @_;
+
+    _log("list_volumes storeid=$storeid vmid=" . (defined $vmid ? $vmid : 'all') . " types=" . join(',', @$content_types));
+
+    my $res = [];
+    my @other = ();
+    for my $type (@$content_types) {
+        if ($type eq 'backup') {
+            my $dir = $class->get_subdir($scfg, 'backup');
+            push @$res, @{ $class->_list_demo_backups($storeid, $dir, $vmid) };
+        } else {
+            push @other, $type;
+        }
+    }
+
+    if (@other) {
+        push @$res, @{ $class->SUPER::list_volumes($storeid, $scfg, $vmid, \@other) };
+    }
+
+    return $res;
+}
+
+sub check_config {
+    my ($class, $sectionId, $config, $create, $skipSchemaCheck) = @_;
+
+    $config->{path} //= '/tmp/demo';
+    _log("check_config section=$sectionId path=$config->{path}");
+
+    return $class->SUPER::check_config($sectionId, $config, $create, $skipSchemaCheck);
+}
+
+sub new_backup_provider {
+    my ($class, $scfg, $storeid, $log_function) = @_;
+    _log("new_backup_provider storeid=$storeid");
+    require PVE::BackupProvider::Plugin::Demo;
+    return PVE::BackupProvider::Plugin::Demo->new($class, $scfg, $storeid, $log_function);
+}
+
+sub api {
+    _log('api requested');
+    return PVE::Storage::APIVER;
+}
+
+1;

--- a/src/PVE/Storage/Makefile
+++ b/src/PVE/Storage/Makefile
@@ -12,9 +12,10 @@ SOURCES= \
 	ZFSPoolPlugin.pm \
 	ZFSPlugin.pm \
 	PBSPlugin.pm \
-	BTRFSPlugin.pm \
-	LvmThinPlugin.pm \
-	ESXiPlugin.pm
+        BTRFSPlugin.pm \
+        LvmThinPlugin.pm \
+       ESXiPlugin.pm \
+       Custom/DemoPlugin.pm
 
 .PHONY: install
 install:


### PR DESCRIPTION
## Summary
- enhance the demo backup provider with detailed logging during restore and backup operations
- log storage plugin actions to `/tmp/demo.log` to aid debugging
- fix VM restore by correctly extracting device names

## Testing
- `make test -C src` *(fails: Can't locate PVE/SafeSyslog.pm)*

------
https://chatgpt.com/codex/tasks/task_e_685c2b63d1f4832c8995ac5fa3f46087